### PR TITLE
Korjaa hintakentän tyhjäksi jättämisestä johtuva bugi

### DIFF
--- a/app/src/main/java/hifian/hintahaukka/EnterPriceActivity.java
+++ b/app/src/main/java/hifian/hintahaukka/EnterPriceActivity.java
@@ -43,8 +43,15 @@ public class EnterPriceActivity extends AppCompatActivity {
     }
 
     private String turnEnteredPriceToCents(String euros, String cents) {
-        int eurosAsInt = Integer.parseInt(euros);
-        int centsasInt = Integer.parseInt(cents);
+        int eurosAsInt = 0;
+        if(!euros.isEmpty()) {
+            eurosAsInt = Integer.parseInt(euros);
+        }
+
+        int centsasInt = 0;
+        if(!cents.isEmpty()) {
+            centsasInt = Integer.parseInt(cents);
+        }
 
         int result = eurosAsInt * 100 + centsasInt;
         return String.valueOf(result);


### PR DESCRIPTION
Hintakentän tyhjäksi jättäminen kaatoi ohjelman. Nyt hinnan senteiksi muuttava metodi ottaa huomioon tyhjäksi jätetyn hinnan mahdollisuuden.