### PR TITLE
Lähetysnapin siirto

### DIFF
--- a/app/src/main/res/layout/fragment_enter_price.xml
+++ b/app/src/main/res/layout/fragment_enter_price.xml
@@ -30,16 +30,16 @@
 
     <EditText
         android:id="@+id/enterEuros"
-        android:layout_width="0dp"
+        android:layout_width="81dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginEnd="4dp"
+        android:digits="0123456789\n.,"
         android:ems="10"
         android:importantForAutofill="no"
         android:inputType="number"
-        android:digits="0123456789\n.,"
         android:textAlignment="center"
-        android:textSize="@dimen/text_large"
+        android:textSize="24sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/label_euros"
         app:layout_constraintHorizontal_bias="0.5"
@@ -50,58 +50,63 @@
         android:id="@+id/label_euros"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
         android:labelFor="@id/enterEuros"
         android:text="@string/text_euro_sign"
-        android:textSize="@dimen/text_large"
-        app:layout_constraintBaseline_toBaselineOf="@+id/enterEuros"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="@+id/enterEuros"
         app:layout_constraintEnd_toStartOf="@+id/enterCents"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/enterEuros" />
+        app:layout_constraintStart_toEndOf="@+id/enterEuros"
+        app:layout_constraintTop_toTopOf="@+id/enterEuros" />
 
     <EditText
         android:id="@+id/enterCents"
-        android:layout_width="0dp"
+        android:layout_width="81dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
         android:ems="10"
         android:importantForAutofill="no"
         android:inputType="number"
         android:maxLength="2"
         android:textAlignment="center"
-        android:textSize="@dimen/text_large"
-        app:layout_constraintBaseline_toBaselineOf="@+id/label_euros"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="@+id/label_euros"
         app:layout_constraintEnd_toStartOf="@+id/label_cents"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/label_euros" />
+        app:layout_constraintStart_toEndOf="@+id/label_euros"
+        app:layout_constraintTop_toTopOf="@+id/label_euros" />
 
     <TextView
         android:id="@+id/label_cents"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="32dp"
+        android:layout_marginStart="4dp"
         android:labelFor="@id/enterCents"
         android:text="@string/text_cents"
-        android:textSize="@dimen/text_large"
-        app:layout_constraintBaseline_toBaselineOf="@+id/enterCents"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="@+id/enterCents"
+        app:layout_constraintEnd_toStartOf="@+id/sendPriceBtn"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/enterCents" />
+        app:layout_constraintStart_toEndOf="@+id/enterCents"
+        app:layout_constraintTop_toTopOf="@+id/enterCents" />
 
     <Button
         android:id="@+id/sendPriceBtn"
-        android:layout_width="0dp"
+        android:layout_width="81dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginEnd="32dp"
-        android:layout_marginBottom="32dp"
         android:backgroundTint="@android:color/holo_green_light"
         android:text="@string/button_send"
         android:textColor="@android:color/white"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/label_cents"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.498"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/label_cents"
+        app:layout_constraintTop_toTopOf="@+id/label_cents" />
 
     <TextView
         android:id="@+id/storeField"

--- a/app/src/main/res/layout/fragment_enter_price.xml
+++ b/app/src/main/res/layout/fragment_enter_price.xml
@@ -7,6 +7,16 @@
     tools:context=".EnterPriceFragment">
 
     <TextView
+        android:id="@+id/storeField"
+        android:layout_width="147dp"
+        android:layout_height="38dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="56dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Kauppa: Punkten" />
+
+    <TextView
         android:id="@+id/eanField"
         android:layout_width="147dp"
         android:layout_height="38dp"
@@ -107,15 +117,5 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/label_cents"
         app:layout_constraintTop_toTopOf="@+id/label_cents" />
-
-    <TextView
-        android:id="@+id/storeField"
-        android:layout_width="147dp"
-        android:layout_height="38dp"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="56dp"
-        android:text="TextView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Siirtää lähetysnapin niin, että käyttäjän kirjoittaessa hintaa skannatulle tuotteelle nappi ei jää avautuvan näppäimistön alle.