### PR TITLE
Korjaus tuotenimen siirtymiseen seuraavaan fragmenttiin

### DIFF
--- a/app/src/main/java/hifian/hintahaukka/GUI/EnterPriceFragment.java
+++ b/app/src/main/java/hifian/hintahaukka/GUI/EnterPriceFragment.java
@@ -194,6 +194,7 @@ public class EnterPriceFragment extends Fragment {
                         sendProductNameButton.setEnabled(false);
                         enterProductNameField.setEnabled(false);
                         enterProductNameField.setText("Kiitos!");
+                        productName = userInputProductName;
                     }
                 }
             });


### PR DESCRIPTION
Minikorjaus, lisätty yksi rivi jotta tuotenimi siirtyy seuraavaan fragmenttiin jo sillä samalla skannauskerralla, kun se on lisätty