### PR TITLE
Vaihda Products-taulun id:ksi kokonaisluku

### DIFF
--- a/app/src/main/java/hifian/hintahaukka/Database/Product.java
+++ b/app/src/main/java/hifian/hintahaukka/Database/Product.java
@@ -1,6 +1,5 @@
 package hifian.hintahaukka.Database;
 
-import androidx.annotation.NonNull;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 
@@ -8,16 +7,16 @@ import androidx.room.PrimaryKey;
 @Entity(tableName = "Products")
 public class Product {
 
-    @NonNull
-    @PrimaryKey
-    private String ean;
+    @PrimaryKey(autoGenerate = true)
+    public int id;
 
+    private String ean;
     private String name;
 
 
-    public Product(@NonNull String ean, String name) {
-        this.name = name;
+    public Product(String ean, String name) {
         this.ean = ean;
+        this.name = name;
     }
 
     public String getName() {

--- a/app/src/main/java/hifian/hintahaukka/Database/ShoppingCartDatabase.java
+++ b/app/src/main/java/hifian/hintahaukka/Database/ShoppingCartDatabase.java
@@ -9,7 +9,7 @@ import androidx.room.RoomDatabase;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-@Database(entities = {Product.class}, version = 1, exportSchema = false)
+@Database(entities = {Product.class}, version = 2, exportSchema = false)
 public abstract class ShoppingCartDatabase extends RoomDatabase {
 
     public abstract ShoppingCartDao shoppingCartDao();


### PR DESCRIPTION
Edellinen ratkaisu käyttää tuotteen ean-koodia id:nä
aiheutti sovelluksen kaatumisen, jos sama tuote lisättiin
otoskoriin kahdesti.

Tietokannan versionumeroa on nostettava, koska tietokannan
rakenteessa tapahtui muutoksia.